### PR TITLE
feat: enable URLs for  group-id and project-id flags

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,7 +13,15 @@ linters:
     - gochecknoglobals
     - exhaustruct
     - ireturn
+    - wsl
   settings:
+    goconst:
+      min-occurrences: 2
+    gocritic:
+      enabled-tags:
+        - performance
+        - style
+        - experimental
     paralleltest:
       ignore-missing: true
       ignore-missing-subtests: true
@@ -22,6 +30,8 @@ linters:
         extended-rules:
           json:
             case: snake
+    misspell:
+      locale: US
   exclusions:
     generated: lax
     warn-unused: true
@@ -54,6 +64,18 @@ linters:
           - goconst
         text: occurrences, make it a constant
         path: "^.*_test\\.go$"
+      - linters:
+          - embeddedstructfieldcheck
+        text: there must be an empty line separating embedded fields from regular fields
+      - linters:
+          - noinlineerr
+        text: avoid inline error handling using `if err := ...; err != nil`; use plain assignment `err := ...`
+      - linters:
+          - wsl_v5
+        text: "missing whitespace above this line"
+
+    # paths:
+    #   - vendor
 
 formatters:
   enable:
@@ -65,6 +87,7 @@ formatters:
   exclusions:
     generated: lax
     # paths:
-    #   - third_party$
-    #   - builtin$
-    #   - examples$
+    # - vendor
+    # - third_party$
+    # - builtin$
+    # - examples$

--- a/README.md
+++ b/README.md
@@ -104,9 +104,29 @@ glreporter tokens ptt --project-id <project-id>
 ### Command-Specific Flags
 
 ```shell
---group-id <group-id>         # GitLab group ID (optional, fetches info from all accessible groups if not provided)
---project-id <project-id>     # GitLab project ID (alternative to group-id for project-specific commands)
+--group-id <group-id>         # GitLab group ID or path with namespace (optional, fetches info from all accessible groups if not provided)
+--project-id <project-id>     # GitLab project ID or path with namespace (alternative to group-id for project-specific commands)
 --include-inactive            # Include inactive tokens in output (token commands only)
+```
+
+### Group and Project ID Formats
+
+The `--group-id` and `--project-id` flags accept multiple formats:
+
+- **Numeric ID**: `12345678` (traditional numeric identifier)
+- **Path with namespace**: `org/subgroup` or `org/subgroup/project` (GitLab namespace path)
+
+**Examples:**
+
+```shell
+# Using numeric ID
+glreporter groups --group-id 12345678
+
+# Using namespace path
+glreporter groups --group-id gitlab-org/gitlab
+
+# Project examples
+glreporter tokens pat --project-id org/project-name
 ```
 
 **Note**: For token commands, use either `--group-id` (to fetch from all projects in a group) or `--project-id` (to fetch from a specific project), but not both. If neither is provided, the command will fetch tokens from all accessible groups or projects.

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/andreygrechin/glreporter/internal/glclient"
 	"github.com/andreygrechin/glreporter/internal/output"
 	"github.com/spf13/cobra"
@@ -10,15 +12,19 @@ import (
 var projectsCmd = &cobra.Command{
 	Use:   "projects",
 	Short: "Fetches and displays information about projects",
-	Long: `Fetches and displays information about GitLab projects. If a group ID is provided, 
-it will fetch all projects from that group and its subgroups. 
+	Long: `Fetches and displays information about GitLab projects. If a group ID is provided,
+it will fetch all projects from that group and its subgroups.
 If no group ID is provided, it will fetch projects from all accessible groups.`,
+	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		groupID = strings.Trim(groupID, "/")
+	},
 	RunE: runProjects,
 }
 
 func init() {
-	projectsCmd.PersistentFlags().IntVar(&groupID, "group-id", 0,
-		"The ID of the top-level GitLab group to start the search from "+
+	projectsCmd.PersistentFlags().StringVar(&groupID, "group-id", "",
+		"The ID or path of the top-level GitLab group to start the search from. "+
+			"Can be a numeric ID, a path with namespace (org/subgroup/project). "+
 			"(optional, fetches from all accessible groups if not provided)")
 
 	RootCmd.AddCommand(projectsCmd)
@@ -26,7 +32,7 @@ func init() {
 
 func runProjects(_ *cobra.Command, _ []string) error {
 	return runReportCommand(
-		func(client *glclient.Client, groupID int) ([]*gitlab.Project, error) {
+		func(client *glclient.Client, groupID string) ([]*gitlab.Project, error) {
 			return client.GetProjectsRecursively(groupID)
 		},
 		func(formatter output.Formatter, data []*gitlab.Project) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	groupID   int
-	projectID int
+	groupID   string
+	projectID string
 	format    string
 	token     string
 	debug     bool
@@ -23,8 +23,6 @@ var (
 var (
 	ErrGitLabTokenRequired = errors.New(
 		"gitlab token is required. Use --token flag or set GITLAB_TOKEN environment variable")
-	ErrGroupOrProjectIDRequired = errors.New(
-		"either --group-id or --project-id must be specified")
 	ErrBothGroupIDAndProjectIDProvided = errors.New(
 		"cannot specify both --group-id and --project-id")
 )
@@ -66,7 +64,7 @@ func IsDebugEnabled() bool {
 
 // runReportCommand is a generic function to handle common logic for fetching and formatting data.
 func runReportCommand[T any](
-	fetchFunc func(client *glclient.Client, groupID int) ([]T, error),
+	fetchFunc func(client *glclient.Client, groupID string) ([]T, error),
 	formatFunc func(formatter output.Formatter, data []T) error,
 	tokenErr error,
 	spinnerSuffix string,

--- a/cmd/tokens.go
+++ b/cmd/tokens.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
@@ -8,15 +10,21 @@ var tokensCmd = &cobra.Command{
 	Use:   "tokens",
 	Short: "Manage tokens operations",
 	Long:  `Manage various token operations for GitLab groups and projects.`,
+	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		groupID = strings.Trim(groupID, "/")
+		projectID = strings.Trim(projectID, "/")
+	},
 }
 
 func init() {
-	tokensCmd.PersistentFlags().IntVar(&groupID, "group-id", 0,
-		"The ID of a GitLab group to start the search from "+
+	tokensCmd.PersistentFlags().StringVar(&groupID, "group-id", "",
+		"The ID or path of a GitLab group to start the search from. "+
+			"Can be a numeric ID or a path with namespace (org/subgroup). "+
 			"(optional for pat/ptt, fetches from all accessible groups if neither group-id nor project-id is provided).")
 
-	tokensCmd.PersistentFlags().IntVar(&projectID, "project-id", 0,
-		"Project ID to fetch tokens for.")
+	tokensCmd.PersistentFlags().StringVar(&projectID, "project-id", "",
+		"The ID or path of a GitLab project to fetch tokens for. "+
+			"Can be a numeric ID or a path with namespace (org/subgroup/project).")
 
 	RootCmd.AddCommand(tokensCmd)
 	tokensCmd.AddCommand(gatCmd)

--- a/cmd/tokens_gat.go
+++ b/cmd/tokens_gat.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	includeInactive bool
-	fetchAll        bool
+	includeInactiveGAT bool
+	fetchAll           bool
 )
 
 var gatCmd = &cobra.Command{
@@ -24,7 +24,7 @@ var gatCmd = &cobra.Command{
 }
 
 func init() {
-	gatCmd.Flags().BoolVar(&includeInactive, "include-inactive", false, "Include inactive tokens in the output")
+	gatCmd.Flags().BoolVar(&includeInactiveGAT, "include-inactive", false, "Include inactive tokens in the output")
 	gatCmd.Flags().BoolVar(&fetchAll, "all", true, "Fetch tokens from all subgroups")
 }
 
@@ -45,9 +45,9 @@ func runGAT(_ *cobra.Command, _ []string) error {
 
 	var tokens []*glclient.GroupAccessTokenWithGroup
 	if fetchAll {
-		tokens, err = client.GetGroupAccessTokensRecursively(groupID, includeInactive)
+		tokens, err = client.GetGroupAccessTokensRecursively(groupID, includeInactiveGAT)
 	} else {
-		tokens, err = client.GetGroupAccessTokens(groupID, includeInactive)
+		tokens, err = client.GetGroupAccessTokens(groupID, includeInactiveGAT)
 	}
 
 	s.Stop()

--- a/cmd/tokens_pat.go
+++ b/cmd/tokens_pat.go
@@ -26,6 +26,7 @@ var patCmd = &cobra.Command{
 func init() {
 	patCmd.Flags().BoolVar(&includeInactivePAT, "include-inactive", false,
 		"Include inactive tokens in the output")
+	patCmd.MarkFlagsMutuallyExclusive("group-id", "project-id")
 }
 
 func runPAT(_ *cobra.Command, _ []string) error {
@@ -64,13 +65,13 @@ func runPAT(_ *cobra.Command, _ []string) error {
 }
 
 func fetchTokens(client *glclient.Client) ([]*glclient.ProjectAccessTokenWithProject, error) {
-	if groupID != 0 && projectID != 0 {
+	if groupID != "" && projectID != "" {
 		return nil, ErrBothGroupIDAndProjectIDProvided
 	}
 
 	// If neither is specified, fetch from all accessible groups
-	if groupID == 0 && projectID == 0 {
-		tokens, err := client.GetProjectAccessTokensRecursively(0, includeInactivePAT)
+	if groupID == "" && projectID == "" {
+		tokens, err := client.GetProjectAccessTokensRecursively("", includeInactivePAT)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch project access tokens from all groups: %w", err)
 		}
@@ -78,7 +79,7 @@ func fetchTokens(client *glclient.Client) ([]*glclient.ProjectAccessTokenWithPro
 		return tokens, nil
 	}
 
-	if groupID != 0 {
+	if groupID != "" {
 		tokens, err := client.GetProjectAccessTokensRecursively(groupID, includeInactivePAT)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch project access tokens recursively: %w", err)

--- a/cmd/tokens_ptt.go
+++ b/cmd/tokens_ptt.go
@@ -22,6 +22,7 @@ var pttCmd = &cobra.Command{
 }
 
 func init() {
+	pttCmd.MarkFlagsMutuallyExclusive("group-id", "project-id")
 }
 
 func runPTT(_ *cobra.Command, _ []string) error {
@@ -64,13 +65,13 @@ func runPTT(_ *cobra.Command, _ []string) error {
 }
 
 func fetchTriggers(client *glclient.Client) ([]*glclient.PipelineTriggerWithProject, error) {
-	if groupID != 0 && projectID != 0 {
+	if groupID != "" && projectID != "" {
 		return nil, ErrBothGroupIDAndProjectIDProvided
 	}
 
 	// If neither is specified, fetch from all accessible groups
-	if groupID == 0 && projectID == 0 {
-		triggers, err := client.GetPipelineTriggersRecursively(0)
+	if groupID == "" && projectID == "" {
+		triggers, err := client.GetPipelineTriggersRecursively("")
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch pipeline triggers from all groups: %w", err)
 		}
@@ -78,7 +79,7 @@ func fetchTriggers(client *glclient.Client) ([]*glclient.PipelineTriggerWithProj
 		return triggers, nil
 	}
 
-	if groupID != 0 {
+	if groupID != "" {
 		triggers, err := client.GetPipelineTriggersRecursively(groupID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch pipeline triggers: %w", err)


### PR DESCRIPTION
This pull adds support for string-based IDs for group (`org/subgroup`) and project identifiers (`org/subgroup`)  and improves flag validation logic across multiple commands.

### Enhanced Namespace Path Support

* Updated all commands (`cmd/groups.go`, `cmd/projects.go`, `cmd/tokens.go`, `cmd/variables.go`) to support both numeric IDs and namespace paths for `--group-id` and `--project-id`. [[1]](diffhunk://#diff-4fb53ead290eabef5d5af065be46892de1bddc6215bc00d9c197b43398a992a5R18-R35) [[2]](diffhunk://#diff-e82952d2819fa0443c40e71a2fe089728d309318d933843449ff63d6ccd3ef2dR18-R35) [[3]](diffhunk://#diff-5562193d29beab51e118b9c59d78b7c0f7f1e812b97920671c20c4e6e0931ccbR4-R27) [[4]](diffhunk://#diff-206c4a8a3f354f031e426a3dea974a1026e65c2a729de0b4c7cc2509c5795119R21-R39) [[5]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL16-R17)

* Extended the `README.md` documentation to clarify supported formats for `--group-id` and `--project-id`, including examples for numeric IDs and namespace paths.

### Improved Flag Validation

* Added mutually exclusive flag validation for `--group-id` and `--project-id` in commands like `tokens`, `variables`, and `ptt` to prevent conflicts when both flags are provided. [[1]](diffhunk://#diff-ed78530c24cfc7be1c0fa38ea62b9337379f526325ac9684a994219df1ff9ac2R29) [[2]](diffhunk://#diff-248e7542dd7f7b89bfac636d6adad2c4e90d0b1ce3d6660858432505fbb0e0f6R25) [[3]](diffhunk://#diff-206c4a8a3f354f031e426a3dea974a1026e65c2a729de0b4c7cc2509c5795119R21-R39)

* Refined error handling logic to ensure proper validation when neither or both flags are provided. [[1]](diffhunk://#diff-ed78530c24cfc7be1c0fa38ea62b9337379f526325ac9684a994219df1ff9ac2L67-R82) [[2]](diffhunk://#diff-248e7542dd7f7b89bfac636d6adad2c4e90d0b1ce3d6660858432505fbb0e0f6L67-R82) [[3]](diffhunk://#diff-206c4a8a3f354f031e426a3dea974a1026e65c2a729de0b4c7cc2509c5795119L77-R84)