### PR TITLE
feat: exclude sensitive values from outputs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,11 +13,12 @@ import (
 )
 
 var (
-	groupID   string
-	projectID string
-	format    string
-	token     string
-	debug     bool
+	groupID       string
+	projectID     string
+	format        string
+	token         string
+	debug         bool
+	includeValues bool
 )
 
 var (

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -32,6 +32,9 @@ Can be a numeric ID or a path with namespace (org/subgroup).`)
 		`The ID or path of a GitLab project to fetch tokens for.
 Can be a numeric ID or a path with namespace (org/subgroup/project).`)
 
+	variablesCmd.PersistentFlags().BoolVar(&includeValues, "include-values", false,
+		"Include variable values in output (excluded by default for security)")
+
 	variablesCmd.MarkFlagsMutuallyExclusive("group-id", "project-id")
 
 	variablesAllCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {

--- a/cmd/variables_all.go
+++ b/cmd/variables_all.go
@@ -122,7 +122,7 @@ func formatAllVariables(
 		return nil
 	}
 
-	if err := formatter.FormatUnifiedVariables(allVariables); err != nil {
+	if err := formatter.FormatUnifiedVariables(allVariables, includeValues); err != nil {
 		return fmt.Errorf("failed to format variables: %w", err)
 	}
 

--- a/cmd/variables_group.go
+++ b/cmd/variables_group.go
@@ -70,7 +70,7 @@ func runVariablesGroup(_ *cobra.Command, _ []string) error {
 	s.Stop()
 
 	// Format variables
-	if err := formatter.FormatGroupVariables(variables); err != nil {
+	if err := formatter.FormatGroupVariables(variables, includeValues); err != nil {
 		return fmt.Errorf("failed to format variables: %w", err)
 	}
 

--- a/cmd/variables_project.go
+++ b/cmd/variables_project.go
@@ -72,7 +72,7 @@ func runVariablesProject(_ *cobra.Command, _ []string) error {
 	s.Stop()
 
 	// Format variables
-	if err := formatter.FormatProjectVariables(variables); err != nil {
+	if err := formatter.FormatProjectVariables(variables, includeValues); err != nil {
 		return fmt.Errorf("failed to format variables: %w", err)
 	}
 

--- a/internal/glclient/client.go
+++ b/internal/glclient/client.go
@@ -72,6 +72,55 @@ type VariableWithSource struct {
 	SourceNamespace  string `json:"source_namespace,omitempty"` // only for projects
 }
 
+// ProjectVariableWithProjectFiltered represents a project variable without the Value field for security.
+type ProjectVariableWithProjectFiltered struct {
+	Key              string                   `json:"key"`
+	VariableType     gitlab.VariableTypeValue `json:"variable_type"`
+	Protected        bool                     `json:"protected"`
+	Masked           bool                     `json:"masked"`
+	Hidden           bool                     `json:"hidden"`
+	Raw              bool                     `json:"raw"`
+	EnvironmentScope string                   `json:"environment_scope"`
+	Description      string                   `json:"description"`
+	ProjectName      string                   `json:"project_name"`
+	ProjectPath      string                   `json:"project_path"`
+	ProjectNamespace string                   `json:"project_namespace"`
+	ProjectWebURL    string                   `json:"project_web_url"`
+}
+
+// GroupVariableWithGroupFiltered represents a group variable without the Value field for security.
+type GroupVariableWithGroupFiltered struct {
+	Key              string                   `json:"key"`
+	VariableType     gitlab.VariableTypeValue `json:"variable_type"`
+	Protected        bool                     `json:"protected"`
+	Masked           bool                     `json:"masked"`
+	Hidden           bool                     `json:"hidden"`
+	Raw              bool                     `json:"raw"`
+	EnvironmentScope string                   `json:"environment_scope"`
+	Description      string                   `json:"description"`
+	GroupName        string                   `json:"group_name"`
+	GroupPath        string                   `json:"group_path"`
+	GroupWebURL      string                   `json:"group_web_url"`
+	GroupFullPath    string                   `json:"group_full_path"`
+}
+
+// VariableWithSourceFiltered represents a variable without the Value field for security.
+type VariableWithSourceFiltered struct {
+	Key              string `json:"key"`
+	VariableType     string `json:"variable_type"`
+	Protected        bool   `json:"protected"`
+	Masked           bool   `json:"masked"`
+	Hidden           bool   `json:"hidden"`
+	Raw              bool   `json:"raw"`
+	EnvironmentScope string `json:"environment_scope"`
+	Description      string `json:"description"`
+	Source           string `json:"source"` // "project" or "group"
+	SourceName       string `json:"source_name"`
+	SourcePath       string `json:"source_path"`
+	SourceWebURL     string `json:"source_web_url"`
+	SourceNamespace  string `json:"source_namespace,omitempty"` // only for projects
+}
+
 // ConvertProjectVariableToUnified converts a ProjectVariableWithProject to VariableWithSource.
 func ConvertProjectVariableToUnified(pv *ProjectVariableWithProject) *VariableWithSource {
 	return &VariableWithSource{

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -32,6 +32,7 @@ const (
 	defaultLastUsedText    string = "Never"
 	defaultTextPlaceholder string = "N/A"
 	defaultTimeFormat      string = "2006-01-02 15:04:05Z"
+	excludedFieldName      string = "value"
 )
 
 type Formatter interface {
@@ -40,9 +41,9 @@ type Formatter interface {
 	FormatGroupAccessTokens(tokens []*glclient.GroupAccessTokenWithGroup) error
 	FormatProjectAccessTokens(tokens []*glclient.ProjectAccessTokenWithProject) error
 	FormatPipelineTriggers(triggers []*glclient.PipelineTriggerWithProject) error
-	FormatProjectVariables(variables []*glclient.ProjectVariableWithProject) error
-	FormatGroupVariables(variables []*glclient.GroupVariableWithGroup) error
-	FormatUnifiedVariables(variables []*glclient.VariableWithSource) error
+	FormatProjectVariables(variables []*glclient.ProjectVariableWithProject, includeValues bool) error
+	FormatGroupVariables(variables []*glclient.GroupVariableWithGroup, includeValues bool) error
+	FormatUnifiedVariables(variables []*glclient.VariableWithSource, includeValues bool) error
 }
 
 func NewFormatter(format Format) (Formatter, error) {
@@ -161,7 +162,7 @@ func (f *TableFormatter) FormatPipelineTriggers(triggers []*glclient.PipelineTri
 	return nil
 }
 
-func (f *TableFormatter) FormatProjectVariables(variables []*glclient.ProjectVariableWithProject) error {
+func (f *TableFormatter) FormatProjectVariables(variables []*glclient.ProjectVariableWithProject, _ bool) error {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.AppendHeader(table.Row{"Project Path", "Key", "Type", "Protected", "Masked", "Environment"})
@@ -185,7 +186,7 @@ func (f *TableFormatter) FormatProjectVariables(variables []*glclient.ProjectVar
 	return nil
 }
 
-func (f *TableFormatter) FormatGroupVariables(variables []*glclient.GroupVariableWithGroup) error {
+func (f *TableFormatter) FormatGroupVariables(variables []*glclient.GroupVariableWithGroup, _ bool) error {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.AppendHeader(table.Row{"Group Path", "Key", "Type", "Protected", "Masked", "Environment"})
@@ -209,7 +210,7 @@ func (f *TableFormatter) FormatGroupVariables(variables []*glclient.GroupVariabl
 	return nil
 }
 
-func (f *TableFormatter) FormatUnifiedVariables(variables []*glclient.VariableWithSource) error {
+func (f *TableFormatter) FormatUnifiedVariables(variables []*glclient.VariableWithSource, _ bool) error {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.AppendHeader(table.Row{"Source", "Path", "Key", "Type", "Protected", "Masked", "Environment"})
@@ -296,34 +297,122 @@ func (f *JSONFormatter) FormatPipelineTriggers(triggers []*glclient.PipelineTrig
 	return nil
 }
 
-func (f *JSONFormatter) FormatProjectVariables(variables []*glclient.ProjectVariableWithProject) error {
+func (f *JSONFormatter) FormatProjectVariables(
+	variables []*glclient.ProjectVariableWithProject,
+	includeValues bool,
+) error {
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 
-	if err := encoder.Encode(variables); err != nil {
-		return fmt.Errorf("failed to encode project variables as JSON: %w", err)
+	if includeValues {
+		if err := encoder.Encode(variables); err != nil {
+			return fmt.Errorf("failed to encode project variables as JSON: %w", err)
+		}
+	} else {
+		// Convert to filtered structs without Value field
+		filtered := filterProjectVariables(variables)
+		if err := encoder.Encode(filtered); err != nil {
+			return fmt.Errorf("failed to encode project variables as JSON: %w", err)
+		}
 	}
 
 	return nil
 }
 
-func (f *JSONFormatter) FormatGroupVariables(variables []*glclient.GroupVariableWithGroup) error {
+func filterProjectVariables(variables []*glclient.ProjectVariableWithProject) any {
+	filtered := make([]*glclient.ProjectVariableWithProjectFiltered, len(variables))
+	for i, v := range variables {
+		filtered[i] = &glclient.ProjectVariableWithProjectFiltered{
+			Key:              v.Key,
+			VariableType:     v.VariableType,
+			Protected:        v.Protected,
+			Masked:           v.Masked,
+			Hidden:           v.Hidden,
+			Raw:              v.Raw,
+			EnvironmentScope: v.EnvironmentScope,
+			Description:      v.Description,
+			ProjectName:      v.ProjectName,
+			ProjectPath:      v.ProjectPath,
+			ProjectNamespace: v.ProjectNamespace,
+			ProjectWebURL:    v.ProjectWebURL,
+		}
+	}
+
+	return filtered
+}
+
+func (f *JSONFormatter) FormatGroupVariables(variables []*glclient.GroupVariableWithGroup, includeValues bool) error {
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 
-	if err := encoder.Encode(variables); err != nil {
-		return fmt.Errorf("failed to encode group variables as JSON: %w", err)
+	if includeValues {
+		if err := encoder.Encode(variables); err != nil {
+			return fmt.Errorf("failed to encode group variables as JSON: %w", err)
+		}
+	} else {
+		// Convert to filtered structs without Value field
+		filtered := filterGroupVariables(variables)
+		if err := encoder.Encode(filtered); err != nil {
+			return fmt.Errorf("failed to encode group variables as JSON: %w", err)
+		}
 	}
 
 	return nil
 }
 
-func (f *JSONFormatter) FormatUnifiedVariables(variables []*glclient.VariableWithSource) error {
+func filterGroupVariables(variables []*glclient.GroupVariableWithGroup) any {
+	filtered := make([]*glclient.GroupVariableWithGroupFiltered, len(variables))
+	for i, v := range variables {
+		filtered[i] = &glclient.GroupVariableWithGroupFiltered{
+			Key:              v.Key,
+			VariableType:     v.VariableType,
+			Protected:        v.Protected,
+			Masked:           v.Masked,
+			Hidden:           v.Hidden,
+			Raw:              v.Raw,
+			EnvironmentScope: v.EnvironmentScope,
+			Description:      v.Description,
+			GroupName:        v.GroupName,
+			GroupPath:        v.GroupPath,
+			GroupWebURL:      v.GroupWebURL,
+			GroupFullPath:    v.GroupFullPath,
+		}
+	}
+
+	return filtered
+}
+
+func (f *JSONFormatter) FormatUnifiedVariables(variables []*glclient.VariableWithSource, includeValues bool) error {
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 
-	if err := encoder.Encode(variables); err != nil {
-		return fmt.Errorf("failed to encode unified variables as JSON: %w", err)
+	if includeValues {
+		if err := encoder.Encode(variables); err != nil {
+			return fmt.Errorf("failed to encode unified variables as JSON: %w", err)
+		}
+	} else {
+		// Convert to filtered structs without Value field
+		filtered := make([]*glclient.VariableWithSourceFiltered, len(variables))
+		for i, v := range variables {
+			filtered[i] = &glclient.VariableWithSourceFiltered{
+				Key:              v.Key,
+				VariableType:     v.VariableType,
+				Protected:        v.Protected,
+				Masked:           v.Masked,
+				Hidden:           v.Hidden,
+				Raw:              v.Raw,
+				EnvironmentScope: v.EnvironmentScope,
+				Description:      v.Description,
+				Source:           v.Source,
+				SourceName:       v.SourceName,
+				SourcePath:       v.SourcePath,
+				SourceWebURL:     v.SourceWebURL,
+				SourceNamespace:  v.SourceNamespace,
+			}
+		}
+		if err := encoder.Encode(filtered); err != nil {
+			return fmt.Errorf("failed to encode unified variables as JSON: %w", err)
+		}
 	}
 
 	return nil
@@ -423,7 +512,9 @@ func (f *CSVFormatter) FormatProjectAccessTokens(tokens []*glclient.ProjectAcces
 	return nil
 }
 
-func (f *CSVFormatter) FormatProjectVariables(variables []*glclient.ProjectVariableWithProject) error {
+func (f *CSVFormatter) FormatProjectVariables(
+	variables []*glclient.ProjectVariableWithProject, includeValues bool,
+) error {
 	if len(variables) == 0 {
 		return nil
 	}
@@ -431,13 +522,13 @@ func (f *CSVFormatter) FormatProjectVariables(variables []*glclient.ProjectVaria
 	writer := csv.NewWriter(os.Stdout)
 	defer writer.Flush()
 
-	headers := getCSVHeaders(variables[0])
+	headers := getCSVHeaders(variables[0], includeValues)
 	if err := writer.Write(headers); err != nil {
 		return fmt.Errorf("failed to write CSV headers: %w", err)
 	}
 
 	for _, variable := range variables {
-		row := getCSVRow(variable)
+		row := getCSVRow(variable, includeValues)
 		if err := writer.Write(row); err != nil {
 			return fmt.Errorf("failed to write CSV row: %w", err)
 		}
@@ -446,7 +537,7 @@ func (f *CSVFormatter) FormatProjectVariables(variables []*glclient.ProjectVaria
 	return nil
 }
 
-func (f *CSVFormatter) FormatGroupVariables(variables []*glclient.GroupVariableWithGroup) error {
+func (f *CSVFormatter) FormatGroupVariables(variables []*glclient.GroupVariableWithGroup, includeValues bool) error {
 	if len(variables) == 0 {
 		return nil
 	}
@@ -454,13 +545,13 @@ func (f *CSVFormatter) FormatGroupVariables(variables []*glclient.GroupVariableW
 	writer := csv.NewWriter(os.Stdout)
 	defer writer.Flush()
 
-	headers := getCSVHeaders(variables[0])
+	headers := getCSVHeaders(variables[0], includeValues)
 	if err := writer.Write(headers); err != nil {
 		return fmt.Errorf("failed to write CSV headers: %w", err)
 	}
 
 	for _, variable := range variables {
-		row := getCSVRow(variable)
+		row := getCSVRow(variable, includeValues)
 		if err := writer.Write(row); err != nil {
 			return fmt.Errorf("failed to write CSV row: %w", err)
 		}
@@ -469,7 +560,7 @@ func (f *CSVFormatter) FormatGroupVariables(variables []*glclient.GroupVariableW
 	return nil
 }
 
-func (f *CSVFormatter) FormatUnifiedVariables(variables []*glclient.VariableWithSource) error {
+func (f *CSVFormatter) FormatUnifiedVariables(variables []*glclient.VariableWithSource, includeValues bool) error {
 	if len(variables) == 0 {
 		return nil
 	}
@@ -477,13 +568,13 @@ func (f *CSVFormatter) FormatUnifiedVariables(variables []*glclient.VariableWith
 	writer := csv.NewWriter(os.Stdout)
 	defer writer.Flush()
 
-	headers := getCSVHeaders(variables[0])
+	headers := getCSVHeaders(variables[0], includeValues)
 	if err := writer.Write(headers); err != nil {
 		return fmt.Errorf("failed to write CSV headers: %w", err)
 	}
 
 	for _, variable := range variables {
-		row := getCSVRow(variable)
+		row := getCSVRow(variable, includeValues)
 		if err := writer.Write(row); err != nil {
 			return fmt.Errorf("failed to write CSV row: %w", err)
 		}
@@ -492,8 +583,9 @@ func (f *CSVFormatter) FormatUnifiedVariables(variables []*glclient.VariableWith
 	return nil
 }
 
-func getCSVHeaders(v interface{}) []string {
+func getCSVHeaders(v interface{}, includeValues ...bool) []string {
 	var headers []string
+	skipValue := len(includeValues) > 0 && !includeValues[0]
 
 	val := reflect.ValueOf(v).Elem()
 	typ := val.Type()
@@ -506,17 +598,21 @@ func getCSVHeaders(v interface{}) []string {
 			// Create a zero value of the embedded type to extract headers
 			embeddedType := field.Type.Elem()
 			embeddedVal := reflect.New(embeddedType)
-			embeddedHeaders := getCSVHeaders(embeddedVal.Interface())
+			embeddedHeaders := getCSVHeaders(embeddedVal.Interface(), includeValues...)
 			headers = append(headers, embeddedHeaders...)
 		case field.Anonymous && field.Type.Kind() == reflect.Struct:
 			// Handle non-pointer embedded structs
 			embeddedVal := reflect.New(field.Type)
-			embeddedHeaders := getCSVHeaders(embeddedVal.Interface())
+			embeddedHeaders := getCSVHeaders(embeddedVal.Interface(), includeValues...)
 			headers = append(headers, embeddedHeaders...)
 		default:
 			// Regular field
 			jsonTag := field.Tag.Get("json")
 			if jsonTag != "" && jsonTag != "-" {
+				// Skip value field if includeValues is false
+				if skipValue && jsonTag == excludedFieldName {
+					continue
+				}
 				headers = append(headers, jsonTag)
 			}
 		}
@@ -525,8 +621,9 @@ func getCSVHeaders(v interface{}) []string {
 	return headers
 }
 
-func getCSVRow(v interface{}) []string {
+func getCSVRow(v interface{}, includeValues ...bool) []string {
 	var row []string
+	skipValue := len(includeValues) > 0 && !includeValues[0]
 
 	val := reflect.ValueOf(v).Elem()
 	typ := val.Type()
@@ -537,13 +634,17 @@ func getCSVRow(v interface{}) []string {
 
 		switch {
 		case field.Anonymous && field.Type.Kind() == reflect.Ptr:
-			row = append(row, getEmbeddedCSVRow(fieldValue)...)
+			row = append(row, getEmbeddedCSVRow(fieldValue, includeValues...)...)
 		case field.Anonymous && field.Type.Kind() == reflect.Struct:
-			row = append(row, getEmbeddedCSVRow(fieldValue.Addr())...)
+			row = append(row, getEmbeddedCSVRow(fieldValue.Addr(), includeValues...)...)
 		default:
 			// Regular field
 			jsonTag := field.Tag.Get("json")
 			if jsonTag != "" && jsonTag != "-" {
+				// Skip value field if includeValues is false
+				if skipValue && jsonTag == excludedFieldName {
+					continue
+				}
 				row = append(row, fmt.Sprintf("%v", fieldValue.Interface()))
 			}
 		}
@@ -552,17 +653,17 @@ func getCSVRow(v interface{}) []string {
 	return row
 }
 
-func getEmbeddedCSVRow(fieldValue reflect.Value) []string {
+func getEmbeddedCSVRow(fieldValue reflect.Value, includeValues ...bool) []string {
 	var row []string
 
 	if !fieldValue.IsNil() {
-		embeddedRow := getCSVRow(fieldValue.Interface())
+		embeddedRow := getCSVRow(fieldValue.Interface(), includeValues...)
 		row = append(row, embeddedRow...)
 	} else {
 		// Count the number of fields in the embedded struct to add empty values
 		embeddedType := fieldValue.Type().Elem()
 		embeddedVal := reflect.New(embeddedType)
-		embeddedHeaders := getCSVHeaders(embeddedVal.Interface())
+		embeddedHeaders := getCSVHeaders(embeddedVal.Interface(), includeValues...)
 
 		for range embeddedHeaders {
 			row = append(row, "")

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -124,3 +124,28 @@ func captureStdout(t *testing.T) *os.File {
 func restoreStdout(old *os.File) {
 	os.Stdout = old
 }
+
+func TestCSVFormatterHandlesNilEmbeddedStructs(t *testing.T) {
+	// Test case where embedded pointer struct might be nil
+	testVariables := []*glclient.ProjectVariableWithProject{
+		{
+			// ProjectVariable is nil - this tests the nil embedded struct handling
+			ProjectVariable:  nil,
+			ProjectName:      "test-project",
+			ProjectPath:      "test/project",
+			ProjectNamespace: "test",
+			ProjectWebURL:    "https://gitlab.com/test/project",
+		},
+	}
+
+	formatter, err := output.NewFormatter(output.FormatCSV)
+	require.NoError(t, err)
+
+	// Capture stdout
+	old := captureStdout(t)
+	defer restoreStdout(old)
+
+	// This should not panic even with nil embedded struct
+	err = formatter.FormatProjectVariables(testVariables, true)
+	assert.NoError(t, err)
+}

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -73,7 +73,7 @@ func TestFormatProjectVariables(t *testing.T) {
 		old := captureStdout(t)
 		defer restoreStdout(old)
 
-		err = formatter.FormatProjectVariables(testVariables)
+		err = formatter.FormatProjectVariables(testVariables, true)
 		assert.NoError(t, err)
 	})
 
@@ -85,7 +85,7 @@ func TestFormatProjectVariables(t *testing.T) {
 		old := captureStdout(t)
 		defer restoreStdout(old)
 
-		err = formatter.FormatProjectVariables(testVariables)
+		err = formatter.FormatProjectVariables(testVariables, true)
 		assert.NoError(t, err)
 	})
 
@@ -97,7 +97,7 @@ func TestFormatProjectVariables(t *testing.T) {
 		old := captureStdout(t)
 		defer restoreStdout(old)
 
-		err = formatter.FormatProjectVariables(testVariables)
+		err = formatter.FormatProjectVariables(testVariables, true)
 		assert.NoError(t, err)
 	})
 
@@ -105,7 +105,7 @@ func TestFormatProjectVariables(t *testing.T) {
 		formatter, err := output.NewFormatter(output.FormatTable)
 		require.NoError(t, err)
 
-		err = formatter.FormatProjectVariables([]*glclient.ProjectVariableWithProject{})
+		err = formatter.FormatProjectVariables([]*glclient.ProjectVariableWithProject{}, true)
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
- By default, variable values are excluded for security reasons.
- Introduce a flag `--include-values` to the `variables` command to include variable values in the CSV/JSON outputs.
- Table outputs don't support that flag and will always exclude variable values.